### PR TITLE
Query status should be a list or a string

### DIFF
--- a/pytrac/ticket.py
+++ b/pytrac/ticket.py
@@ -22,7 +22,18 @@ class Ticket(object):
                           xmlrpclib.Fault,
                           max_tries=3)
     def search(self, summary=None, owner=None, status=None, order=None, ticket_type=None, descending=None, max=0):
-        ''' search for tickets, return ticket ids'''
+        ''' search for tickets, return ticket ids
+
+        Args:
+            - summary (string, optional): ticket summary
+            - owner (string, optional): owner of the ticket
+            - status (string or list of strings, optional): status of the ticket
+            - order (string, optional): field name for ordering
+            - descending (boolean, optional): if you want to order descending
+              or not
+            - max (int, default 0): maximum number of items in the reurned
+              list
+        '''
         query = ''
         if summary:
             query += "summary~=%s&" % summary

--- a/pytrac/ticket.py
+++ b/pytrac/ticket.py
@@ -29,7 +29,13 @@ class Ticket(object):
         if owner:
             query += "owner=%s&" % owner
         if status:
-            query += "status=%s&" % status
+            # We're not duck typing as strings are iterable, but we don't want
+            # to iterate over a string here, only over iterables, so let's
+            # check that first
+            if type(status) == str:
+                query += "status=%s&" % status
+            else:
+                query += "status=%s&" % '|'.join(status)
         if ticket_type:
             query += "type=%s&" % ticket_type
         if order:

--- a/test/test_ticket.py
+++ b/test/test_ticket.py
@@ -22,6 +22,21 @@ class TestTicket(object):
         self.ticket.search(summary='test_summary', owner='someowner', status='new', ticket_type='Task', order='id', descending=True, max=10)
         self.ticket.api.query.assert_called_with('summary~=test_summary&owner=someowner&status=new&type=Task&order=id&desc=true&max=10')
 
+    def testSearchWithStatusList(self):
+        '''search for tickets specifying several possible statuses'''
+
+        self.ticket.search(
+            summary='test_summary',
+            owner='someowner',
+            status=['new', 'next', 'doing'],
+        )
+
+        querystring = 'summary~=test_summary'\
+            '&owner=someowner'\
+            '&status=new|next|doing'\
+            '&max=0'
+        self.ticket.api.query.assert_called_with(querystring)
+
 
 class TestUpdateTicket(object):
 


### PR DESCRIPTION
This is desirable if you're interested in tickets which might have one of several possible states.